### PR TITLE
fixed frontera scheduler

### DIFF
--- a/frontera/contrib/scrapy/schedulers/frontier.py
+++ b/frontera/contrib/scrapy/schedulers/frontier.py
@@ -108,8 +108,7 @@ class FronteraScheduler(Scheduler):
             for element in result:
                 if isinstance(element, Request):
                     links.append(element)
-                else:
-                    yield element
+                yield element
         except Exception as e:
             self.process_exception(response.request, e, spider)
             raise e


### PR DESCRIPTION
fixes GH-3

scrapy [docs](https://doc.scrapy.org/en/latest/topics/spider-middleware.html?highlight=process_spider_output#scrapy.spidermiddlewares.SpiderMiddleware.process_spider_output) say the following about `process_spider_exception`

> `process_spider_output()` must return an iterable of Request, dict or Item objects.

 `process_spider_output ` in frontera was not yielding requests which would cause a problem for other middlewares like the referer middlewares. This [line](https://github.com/scrapy/scrapy/blob/master/scrapy/spidermiddlewares/referer.py#L22) in particular wasn't working earlier. 

Here's a screenshot of working referer headers: 
<img width="1680" alt="screen shot 2017-02-06 at 12 58 59 pm" src="https://cloud.githubusercontent.com/assets/8171193/22638135/3cebdfb6-ec6c-11e6-9c62-b28ec54751ea.png">
