### PR TITLE
attach response to ignore request

### DIFF
--- a/frontera/contrib/scrapy/middlewares/schedulers.py
+++ b/frontera/contrib/scrapy/middlewares/schedulers.py
@@ -1,10 +1,17 @@
 import logging
 
-from scrapy.exceptions import IgnoreRequest
+from scrapy.exceptions import IgnoreRequest as _IgnoreRequest
 from scrapy.spidermiddlewares.httperror import HttpError
 
 
 logger = logging.getLogger(__name__)
+
+
+class IgnoreRequest(_IgnoreRequest):
+
+    def __init__(self, *args, **kwargs):
+        self.response = kwargs.pop('response')
+        super(IgnoreRequest, self).__init__(*args, **kwargs)
 
 
 class BaseSchedulerMiddleware(object):
@@ -43,7 +50,7 @@ class SchedulerDownloaderMiddleware(BaseSchedulerMiddleware):
             logger.debug('adding request to request_error: Got status code: %d' % status_code)
             # maybe shouldn't return response after logging erorr
             self.process_exception(request, HttpError(error_msg), spider)
-            raise IgnoreRequest
+            raise IgnoreRequest(response=response)
         return response
 
     def process_exception(self, request, exception, spider):


### PR DESCRIPTION
Airbnb has a use case where in `errback`, responses with status code other than 200 or 403 have to be logged. Attaching response to `IgnoreRequest` we can achieve this