### PR TITLE
add request to response

### DIFF
--- a/frontera/contrib/scrapy/middlewares/schedulers.py
+++ b/frontera/contrib/scrapy/middlewares/schedulers.py
@@ -50,6 +50,7 @@ class SchedulerDownloaderMiddleware(BaseSchedulerMiddleware):
             logger.debug('adding request to request_error: Got status code: %d' % status_code)
             # maybe shouldn't return response after logging erorr
             self.process_exception(request, HttpError(error_msg), spider)
+            response.request = request
             raise IgnoreRequest(response=response)
         return response
 


### PR DESCRIPTION
Turns out that request is not attached to response before the downloadmiddleware processes it.
```
2017-02-20 18:12:11 [root] ERROR: Response.meta not available, this response is not tied to any request
Traceback (most recent call last):
  File "/Users/voith/Projects/crawler_app/vy_crawlers/extensions/fail_extension.py", line 16, in spider_error
    failure.raiseException()
  File "/Users/voith/Projects/crawler_app/venv/lib/python2.7/site-packages/scrapy/utils/defer.py", line 102, in iter_errback
    yield next(it)
  File "/Users/voith/Projects/crawler_app/vy_crawlers/spiders/airbnb_listings.py", line 123, in log_non_403_404
    for req in self._chk_enqueue(response):
  File "/Users/voith/Projects/crawler_app/vy_crawlers/spiders/airbnb_listings.py", line 144, in _chk_enqueue
    if (response.meta['id'] + 1) == response.meta['next_id'] and response.meta['next_id'] <= max_id:
  File "/Users/voith/Projects/crawler_app/venv/lib/python2.7/site-packages/scrapy/http/response/__init__.py", line 31, in meta
    raise AttributeError("Response.meta not available, this response " \
AttributeError: Response.meta not available, this response is not tied to any request
```