### PR TITLE
preserve traceback of original exception

### DIFF
--- a/frontera/contrib/scrapy/schedulers/frontier.py
+++ b/frontera/contrib/scrapy/schedulers/frontier.py
@@ -111,7 +111,7 @@ class FronteraScheduler(Scheduler):
                 yield element
         except Exception as e:
             self.process_exception(response.request, e, spider)
-            raise e
+            raise
 
         self.frontier.page_crawled(response=response,
                                    links=links)


### PR DESCRIPTION
Last three lines show the traceback for the source of the exception
```
2017-04-04 13:17:02 [root] ERROR:
Traceback (most recent call last):
  File "/Users/voith/Projects/crawler_app/vy_crawlers/extensions/fail_extension.py", line 16, in spider_error
    failure.raiseException()
  File "/Users/voith/Projects/crawler_app/venv/lib/python2.7/site-packages/scrapy/utils/defer.py", line 102, in iter_errback
    yield next(it)
  File "/Users/voith/Projects/crawler_app/venv/lib/python2.7/site-packages/scrapy/spidermiddlewares/offsite.py", line 28, in process_spider_output
    for x in result:
  File "/Users/voith/Projects/crawler_app/venv/lib/python2.7/site-packages/scrapy/spidermiddlewares/referer.py", line 22, in <genexpr>
    return (_set_referer(r) for r in result or ())
  File "/Users/voith/Projects/crawler_app/venv/lib/python2.7/site-packages/scrapy/spidermiddlewares/urllength.py", line 37, in <genexpr>
    return (r for r in result or () if _filter(r))
  File "/Users/voith/Projects/crawler_app/venv/lib/python2.7/site-packages/scrapy/spidermiddlewares/depth.py", line 54, in <genexpr>
    return (r for r in result or () if _filter(r))
  File "/Users/voith/Projects/crawler_app/venv/src/frontera-feature-production/frontera/contrib/scrapy/schedulers/frontier.py", line 108, in process_spider_output
    for element in result:
  File "/Users/voith/Projects/crawler_app/vy_crawlers/spiders/sainsburys.py", line 48, in parse
    raise Exception
Exception
```