### PR TITLE
fixed missing body error

### DIFF
--- a/frontera/contrib/backends/sqlalchemy/__init__.py
+++ b/frontera/contrib/backends/sqlalchemy/__init__.py
@@ -315,6 +315,7 @@ class SQLiteBackend(Backend):
         db_page.meta = obj.meta
         db_page.depth = 0
         db_page.retries = 0
+        db_page.body = None
 
         if not isinstance(obj, frontera_response):
             db_page.headers = obj.headers


### PR DESCRIPTION
was getting the following error
```
2017-12-05 20:17:15 [frontera.contrib.backends.sqlalchemy] ERROR: exception occured in links_extracted: CompileError('INSERT value for column play_store_by_id.body is explicitly rendered as a boundparameter in the VALUES clause; a Python-side value or SQL expression is required',)
Traceback (most recent call last):
  File "/Users/voith/Projects/frontera/frontera/contrib/backends/sqlalchemy/__init__.py", line 40, in func_wrapper
    return func(self, *args, **kwargs)
  File "/Users/voith/Projects/frontera/frontera/contrib/backends/sqlalchemy/__init__.py", line 269, in links_extracted
    self._bulk_insert_ignore(pages)
  File "/Users/voith/Projects/frontera/frontera/contrib/backends/sqlalchemy/__init__.py", line 278, in _bulk_insert_ignore
    self.session.execute(insert_stmt)
  File "/Users/voith/Python-Env/crawler_app/lib/python2.7/site-packages/sqlalchemy/orm/session.py", line 1107, in execute
    bind, close_with_result=True).execute(clause, params or {})
  File "/Users/voith/Python-Env/crawler_app/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 945, in execute
    return meth(self, multiparams, params)
  File "/Users/voith/Python-Env/crawler_app/lib/python2.7/site-packages/sqlalchemy/sql/elements.py", line 263, in _execute_on_connection
    return connection._execute_clauseelement(self, multiparams, params)
  File "/Users/voith/Python-Env/crawler_app/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 1046, in _execute_clauseelement
    if not self.schema_for_object.is_default else None)
  File "<string>", line 1, in <lambda>
  File "/Users/voith/Python-Env/crawler_app/lib/python2.7/site-packages/sqlalchemy/sql/elements.py", line 436, in compile
    return self._compiler(dialect, bind=bind, **kw)
  File "/Users/voith/Python-Env/crawler_app/lib/python2.7/site-packages/sqlalchemy/sql/elements.py", line 442, in _compiler
    return dialect.statement_compiler(dialect, self, **kw)
  File "/Users/voith/Python-Env/crawler_app/lib/python2.7/site-packages/sqlalchemy/sql/compiler.py", line 435, in __init__
    Compiled.__init__(self, dialect, statement, **kwargs)
  File "/Users/voith/Python-Env/crawler_app/lib/python2.7/site-packages/sqlalchemy/sql/compiler.py", line 216, in __init__
    self.string = self.process(self.statement, **compile_kwargs)
  File "/Users/voith/Python-Env/crawler_app/lib/python2.7/site-packages/sqlalchemy/sql/compiler.py", line 242, in process
    return obj._compiler_dispatch(self, **kwargs)
  File "/Users/voith/Python-Env/crawler_app/lib/python2.7/site-packages/sqlalchemy/sql/visitors.py", line 81, in _compiler_dispatch
    return meth(self, **kw)
  File "/Users/voith/Python-Env/crawler_app/lib/python2.7/site-packages/sqlalchemy/sql/compiler.py", line 1968, in visit_insert
    self, insert_stmt, crud.ISINSERT, **kw)
  File "/Users/voith/Python-Env/crawler_app/lib/python2.7/site-packages/sqlalchemy/sql/crud.py", line 57, in _setup_crud_params
    return _get_crud_params(compiler, stmt, **kw)
  File "/Users/voith/Python-Env/crawler_app/lib/python2.7/site-packages/sqlalchemy/sql/crud.py", line 150, in _get_crud_params
    values = _extend_values_for_multiparams(compiler, stmt, values, kw)
  File "/Users/voith/Python-Env/crawler_app/lib/python2.7/site-packages/sqlalchemy/sql/crud.py", line 615, in _extend_values_for_multiparams
    for i, row in enumerate(stmt.parameters[1:])
  File "/Users/voith/Python-Env/crawler_app/lib/python2.7/site-packages/sqlalchemy/sql/crud.py", line 615, in <genexpr>
    for i, row in enumerate(stmt.parameters[1:])
  File "/Users/voith/Python-Env/crawler_app/lib/python2.7/site-packages/sqlalchemy/sql/crud.py", line 416, in _process_multiparam_default_bind
    "a Python-side value or SQL expression is required" % c)
CompileError: INSERT value for column play_store_by_id.body is explicitly rendered as a boundparameter in the VALUES clause; a Python-side value or SQL expression is required
```